### PR TITLE
Expose QPlatformWindow::invalidateSurface as a virtual function.

### DIFF
--- a/src/gui/kernel/qplatformwindow.cpp
+++ b/src/gui/kernel/qplatformwindow.cpp
@@ -509,6 +509,20 @@ static inline const QScreen *effectiveScreen(const QWindow *window)
 }
 
 /*!
+    Invalidates the window's surface by releasing its surface buffers.
+
+    Many platforms do not support releasing the surface memory,
+    and the default implementation does nothing.
+
+    The platform window is expected to recreate the surface again if
+    it is needed. For instance, if an OpenGL context is made current
+    on this window.
+ */
+void QPlatformWindow::invalidateSurface()
+{
+}
+
+/*!
     Helper function to get initial geometry on windowing systems which do not
     do smart positioning and also do not provide a means of centering a
     transient window w.r.t. its parent. For example this is useful on Windows

--- a/src/gui/kernel/qplatformwindow.h
+++ b/src/gui/kernel/qplatformwindow.h
@@ -131,6 +131,8 @@ public:
     virtual void setAlertState(bool enabled);
     virtual bool isAlertState() const;
 
+    virtual void invalidateSurface();
+
     static QRect initialGeometry(const QWindow *w,
         const QRect &initialGeometry, int defaultWidth, int defaultHeight);
 


### PR DESCRIPTION
This can be quite useful on some embedded systems to free up
graphics memory when windows are not used. QEglFSWindow already
implements the function.

Change-Id: I79b08efbd3c67d7be34df6a0e12dd184a92d48c5
Reviewed-by: Laszlo Agocs laszlo.agocs@digia.com
