### PR TITLE
Fix installation of private headers generated by wayland-scanner

### DIFF
--- a/mkspecs/features/wayland-scanner.prf
+++ b/mkspecs/features/wayland-scanner.prf
@@ -32,6 +32,7 @@ qt_install_headers {
     !isEmpty(header_files_client) {
         wayland_generated_client_headers.files = $$header_files_client
         wayland_generated_client_headers.path = $$private_headers.path
+        wayland_generated_client_headers.CONFIG = no_check_exist
         INSTALLS += wayland_generated_client_headers
         WAYLAND_CLIENT_HEADER_DEST = $$header_dest/
         WAYLAND_CLIENT_INCLUDE_DIR = $$MODULE_INCNAME/private
@@ -41,6 +42,7 @@ qt_install_headers {
     !isEmpty(header_files_server) {
         wayland_generated_server_headers.files = $$header_files_server
         wayland_generated_server_headers.path = $$private_headers.path
+        wayland_generated_server_headers.CONFIG = no_check_exist
         INSTALLS += wayland_generated_server_headers
         WAYLAND_SERVER_HEADER_DEST = $$header_dest/
         WAYLAND_SERVER_INCLUDE_DIR = $$MODULE_INCNAME/private


### PR DESCRIPTION
Private qtwayland headers were not installed at first build, since
qmake was ignoring unexisting files from the install target. It
required another run of qmake to have a proper Makefile generated.

The rules for generated headers need CONFIG = no_check_exist, so that
files get listed in the Makefile even if they do not exist yet (thanks
to Loïc Yhuel for the pointer).

Change-Id: I1a0278d629295a55a3ddcf5f8fb068a04ba5be47
Reviewed-by: Oswald Buddenhagen oswald.buddenhagen@digia.com
