### PR TITLE
qmake fix to improve build stability of qtwayland

### DIFF
--- a/mkspecs/features/qt_module_pris.prf
+++ b/mkspecs/features/qt_module_pris.prf
@@ -144,9 +144,11 @@ MODULE_FWD_PRI = $$mod_work_pfx/qt_lib_$${MODULE_ID}.pri
             "QT_MODULE_HOST_LIB_BASE = $$MODULE_BASE_OUTDIR/lib" \
             "QT_MODULE_LIBEXEC_BASE = $$MODULE_BASE_OUTDIR/libexec" \
             "QT_MODULE_PLUGIN_BASE = $$MODULE_BASE_OUTDIR/plugins" \
-            "include($$MODULE_PRI)"
+            "include($$MODULE_PRI)" \
+            "QT.$${MODULE_ID}.priority = 1"
         !internal_module: MODULE_FWD_PRI_CONT += \
-            "include($$MODULE_PRIVATE_PRI)"
+            "include($$MODULE_PRIVATE_PRI)" \
+            "QT.$${MODULE}_private.priority = 1"
         MODULE_FWD_PRI_CONT += $$MODULE_FWD_PRI_CONT_SUFFIX
         write_file($$MODULE_FWD_PRI, MODULE_FWD_PRI_CONT)|error("Aborting.")
         touch($$MODULE_FWD_PRI, $$MODULE_PRI)
@@ -174,7 +176,7 @@ MODULE_FWD_PRI = $$mod_work_pfx/qt_lib_$${MODULE_ID}.pri
     for(mod, mods_to_load) {
         for(var, $$list(VERSION MAJOR_VERSION MINOR_VERSION PATCH_VERSION \
                         name depends module_config CONFIG DEFINES sources \
-                        includes bins libs libexecs plugins imports qml \
+                        priority includes bins libs libexecs plugins imports qml \
                         rpath_link \
                 )):defined(QT.$${mod}.$$var, var):cache(QT.$${mod}.$$var, transient)
     }

--- a/qmake/library/qmakebuiltins.cpp
+++ b/qmake/library/qmakebuiltins.cpp
@@ -436,8 +436,9 @@ QByteArray QMakeEvaluator::getCommandOutput(const QString &args) const
 
 void QMakeEvaluator::populateDeps(
         const ProStringList &deps, const ProString &prefix, const ProStringList &suffixes,
+        const ProString &priosfx,
         QHash<ProKey, QSet<ProKey> > &dependencies, ProValueMap &dependees,
-        ProStringList &rootSet) const
+        QMultiMap<int, ProString> &rootSet) const
 {
     foreach (const ProString &item, deps)
         if (!dependencies.contains(item.toKey())) {
@@ -446,13 +447,13 @@ void QMakeEvaluator::populateDeps(
             foreach (const ProString &suffix, suffixes)
                 depends += values(ProKey(prefix + item + suffix));
             if (depends.isEmpty()) {
-                rootSet << item;
+                rootSet.insert(first(ProKey(prefix + item + priosfx)).toInt(), item);
             } else {
                 foreach (const ProString &dep, depends) {
                     dset.insert(dep.toKey());
                     dependees[dep.toKey()] << item;
                 }
-                populateDeps(depends, prefix, suffixes, dependencies, dependees, rootSet);
+                populateDeps(depends, prefix, suffixes, priosfx, dependencies, dependees, rootSet);
             }
         }
 }
@@ -973,27 +974,31 @@ ProStringList QMakeEvaluator::evaluateBuiltinExpand(
         break;
     case E_SORT_DEPENDS:
     case E_RESOLVE_DEPENDS:
-        if (args.count() < 1 || args.count() > 3) {
-            evalError(fL1S("%1(var, [prefix, [suffixes]]) requires one to three arguments.")
+        if (args.count() < 1 || args.count() > 4) {
+            evalError(fL1S("%1(var, [prefix, [suffixes, [prio-suffix]]]) requires one to four arguments.")
                       .arg(func.toQString(m_tmp1)));
         } else {
             QHash<ProKey, QSet<ProKey> > dependencies;
             ProValueMap dependees;
-            ProStringList rootSet;
+            QMultiMap<int, ProString> rootSet;
             ProStringList orgList = values(args.at(0).toKey());
-            populateDeps(orgList, (args.count() < 2 ? ProString() : args.at(1)),
+            ProString prefix = args.count() < 2 ? ProString() : args.at(1);
+            ProString priosfx = args.count() < 4 ? ProString(".priority") : args.at(3);
+            populateDeps(orgList, prefix,
                          args.count() < 3 ? ProStringList(ProString(".depends"))
                                           : split_value_list(args.at(2).toQString(m_tmp2)),
-                         dependencies, dependees, rootSet);
-            for (int i = 0; i < rootSet.size(); ++i) {
-                const ProString &item = rootSet.at(i);
+                         priosfx, dependencies, dependees, rootSet);
+            while (!rootSet.isEmpty()) {
+                QMultiMap<int, ProString>::iterator it = rootSet.begin();
+                const ProString item = *it;
+                rootSet.erase(it);
                 if ((func_t == E_RESOLVE_DEPENDS) || orgList.contains(item))
                     ret.prepend(item);
                 foreach (const ProString &dep, dependees[item.toKey()]) {
                     QSet<ProKey> &dset = dependencies[dep.toKey()];
-                    dset.remove(rootSet.at(i).toKey()); // *Don't* use 'item' - rootSet may have changed!
+                    dset.remove(item.toKey());
                     if (dset.isEmpty())
-                        rootSet << dep;
+                        rootSet.insert(first(ProKey(prefix + dep + priosfx)).toInt(), dep);
                 }
             }
         }

--- a/qmake/library/qmakeevaluator.h
+++ b/qmake/library/qmakeevaluator.h
@@ -51,6 +51,7 @@
 
 #include <qlist.h>
 #include <qlinkedlist.h>
+#include <qmap.h>
 #include <qset.h>
 #include <qstack.h>
 #include <qstring.h>
@@ -238,8 +239,9 @@ public:
 
     void populateDeps(
             const ProStringList &deps, const ProString &prefix, const ProStringList &suffixes,
-            QHash<ProKey, QSet<ProKey> > &dependencies,
-            ProValueMap &dependees, ProStringList &rootSet) const;
+            const ProString &priosfx,
+            QHash<ProKey, QSet<ProKey> > &dependencies, ProValueMap &dependees,
+            QMultiMap<int, ProString> &rootSet) const;
 
     VisitReturn writeFile(const QString &ctx, const QString &fn, QIODevice::OpenMode mode,
                           const QString &contents);

--- a/tests/auto/tools/qmake/testdata/functions/functions.pro
+++ b/tests/auto/tools/qmake/testdata/functions/functions.pro
@@ -173,3 +173,12 @@ testReplace($$shell_quote($$in), $$out, "shell_quote")
 testReplace($$reverse($$list(one two three)), three two one, "reverse")
 
 testReplace($$cat(textfile), hi '"holla he"' 'hu!')
+
+MOD.a.depends =
+MOD.b.depends =
+MOD.b.priority = 1
+MOD.c.depends = a b
+testReplace($$resolve_depends($$list(c), "MOD."), c b a)
+MOD.a.priority = 1
+MOD.b.priority = 0
+testReplace($$resolve_depends($$list(c), "MOD."), c a b)


### PR DESCRIPTION
This fixes qtwayland (and possibly other modules) build when its api changes and an old version is installed already.
