### PR TITLE
[qtbase] Add Mer specific theme hints back

### DIFF
--- a/src/platformsupport/themes/genericunix/qgenericunixthemes.cpp
+++ b/src/platformsupport/themes/genericunix/qgenericunixthemes.cpp
@@ -160,6 +160,10 @@ QVariant QGenericUnixTheme::themeHint(ThemeHint hint) const
     }
     case QPlatformTheme::KeyboardScheme:
         return QVariant(int(X11KeyboardScheme));
+    case QPlatformTheme::PasswordMaskDelay:
+        return QVariant(1000);
+    case QPlatformTheme::StartDragDistance:
+        return QVariant(20);
     default:
         break;
     }


### PR DESCRIPTION
Originally introduced to mer-packages/qtbase with
62ba0852d9d38aae6b8ff21dbe9464717b12add0

Note: untested.
