### PR TITLE
[qtbase] Fix handling QT_IM_MODULE=none

### DIFF
--- a/src/gui/kernel/qplatforminputcontextfactory.cpp
+++ b/src/gui/kernel/qplatforminputcontextfactory.cpp
@@ -83,7 +83,7 @@ QPlatformInputContext *QPlatformInputContextFactory::create()
     QString icString = QString::fromLatin1(qgetenv("QT_IM_MODULE"));
 
     if (icString == QLatin1String("none"))
-        icString = QStringLiteral("compose");
+        return 0;
 
     ic = create(icString);
     if (ic && ic->isValid())


### PR DESCRIPTION
Was added to allow no input context to be created with 19a39a4e.
Broken by commit 24c10b0b8d7.
