### PR TITLE
Reset QNAM's NetworkConfiguration when state changes.

### DIFF
--- a/src/network/access/qnetworkaccessmanager.cpp
+++ b/src/network/access/qnetworkaccessmanager.cpp
@@ -1130,7 +1130,12 @@ QNetworkReply *QNetworkAccessManager::createRequest(QNetworkAccessManager::Opera
     if (!d->networkSessionStrongRef && (d->initializeSession || !d->networkConfiguration.identifier().isEmpty())) {
         QNetworkConfigurationManager manager;
         if (!d->networkConfiguration.identifier().isEmpty()) {
-            d->createSession(d->networkConfiguration);
+            if ((d->networkConfiguration.state() & QNetworkConfiguration::Defined)
+                    && d->networkConfiguration != manager.defaultConfiguration())
+                d->createSession(manager.defaultConfiguration());
+            else
+                d->createSession(d->networkConfiguration);
+
         } else {
             if (manager.capabilities() & QNetworkConfigurationManager::NetworkSessionRequired)
                 d->createSession(manager.defaultConfiguration());
@@ -1579,6 +1584,11 @@ void QNetworkAccessManagerPrivate::_q_onlineStateChanged(bool isOnline)
     if (customNetworkConfiguration) {
         online = (networkConfiguration.state() & QNetworkConfiguration::Active);
     } else {
+        if (isOnline && online != isOnline) {
+            networkSessionStrongRef.clear();
+            networkSessionWeakRef.clear();
+        }
+
         online = isOnline;
     }
 }


### PR DESCRIPTION
Since QNAM is initialized with defaultConfiguration, we need to
reset the internal configuration used to the current
defaultConfiguration when the state changes and a new configuration
becomes the default.

Task-number: QTBUG-40234
Change-Id: I50f23c62804f29370915eecac2c92301c5f3ead2
Reviewed-by: Kai Koehne kai.koehne@theqtcompany.com
Reviewed-by: Alex Blasche alexander.blasche@digia.com
