### PR TITLE
QPainter: Fix a hard to trigger null dereference in QPainterPrivate::drawTextItem

### DIFF
--- a/src/gui/painting/qpainter.cpp
+++ b/src/gui/painting/qpainter.cpp
@@ -6420,6 +6420,7 @@ void QPainterPrivate::drawTextItem(const QPointF &p, const QTextItem &_ti, QText
                 continue;
 
 
+            multi->ensureEngineAt(which);
             QTextItemInt ti2 = ti.midItem(multi->engine(which), start, end - start);
             ti2.width = 0;
             // set the high byte to zero and calc the width
@@ -6447,6 +6448,7 @@ void QPainterPrivate::drawTextItem(const QPointF &p, const QTextItem &_ti, QText
             which = e;
         }
 
+        multi->ensureEngineAt(which);
         QTextItemInt ti2 = ti.midItem(multi->engine(which), start, end - start);
         ti2.width = 0;
         // set the high byte to zero and calc the width


### PR DESCRIPTION
Done-with: Mohammed Hassan mohammed.hassan@jollamobile.com
Change-Id: I24c724d24346fb5be8c4a66d68a11d51be5ad5f2
Reviewed-by: Eskil Abrahamsen Blomfeldt eskil.abrahamsen-blomfeldt@digia.com
