### PR TITLE
Do not mark non-existent touch points as stationary

### DIFF
--- a/src/platformsupport/input/evdevtouch/qevdevtouch.cpp
+++ b/src/platformsupport/input/evdevtouch/qevdevtouch.cpp
@@ -551,6 +551,10 @@ void QEvdevTouchScreenData::processInputEvent(input_event *data)
         while (it.hasNext()) {
             it.next();
             Contact &contact(it.value());
+
+            if (!contact.state)
+                continue;
+
             if (contact.state == Qt::TouchPointReleased) {
                 if (m_typeB)
                     contact.state = static_cast<Qt::TouchPointState>(0);


### PR DESCRIPTION
Make sure touches that were already released on an earlier
SYN_REPORT are not re-marked as TouchPointStationary.

This change has no effect on type A event processing since there
the contact state is never zeroed.

Change-Id: I2d4d705d2b3fae424b6245a75d4015dc2d86ad35
