### PR TITLE
Add a way to filter window system events

### DIFF
--- a/src/gui/kernel/qwindowsysteminterface_p.h
+++ b/src/gui/kernel/qwindowsysteminterface_p.h
@@ -62,6 +62,8 @@
 
 QT_BEGIN_NAMESPACE
 
+class QWindowSystemEventHandler;
+
 class Q_GUI_EXPORT QWindowSystemInterfacePrivate {
 public:
     enum EventType {
@@ -483,6 +485,17 @@ public:
     static QMutex flushEventMutex;
 
     static QList<QTouchEvent::TouchPoint> convertTouchPoints(const QList<QWindowSystemInterface::TouchPoint> &points, QEvent::Type *type);
+
+    static void installWindowSystemEventHandler(QWindowSystemEventHandler *handler);
+    static void removeWindowSystemEventhandler(QWindowSystemEventHandler *handler);
+    static QWindowSystemEventHandler *eventHandler;
+};
+
+class Q_GUI_EXPORT QWindowSystemEventHandler
+{
+public:
+    virtual ~QWindowSystemEventHandler();
+    virtual bool sendEvent(QWindowSystemInterfacePrivate::WindowSystemEvent *event);
 };
 
 QT_END_NAMESPACE


### PR DESCRIPTION
This change introduces the class QWindowSystemEventHandler
which can be used to hook into QWindowSystemInterfacePrivate to
filter and dispatch window system events.
One use case is to intercept key events from the underlying system
in QtCompositor and feed them into the xkbcommon state, and to modify
the events based on the resulting state.

Change-Id: I829eb7d960420135990fb0f6db54c14eea3e8e48
Reviewed-by: Laszlo Agocs laszlo.agocs@theqtcompany.com
Reviewed-by: Gunnar Sletta gunnar@sletta.org
