### PR TITLE
udev: Do not overwrite original device pointer

### DIFF
--- a/src/platformsupport/devicediscovery/qdevicediscovery_udev.cpp
+++ b/src/platformsupport/devicediscovery/qdevicediscovery_udev.cpp
@@ -206,11 +206,11 @@ void QDeviceDiscovery::handleUDevNotification()
     // if we cannot determine a type, walk up the device tree
     if (!checkDeviceType(dev)) {
         // does not increase the refcount
-        dev = udev_device_get_parent_with_subsystem_devtype(dev, subsystem, 0);
-        if (!dev)
+        struct udev_device *parent_dev = udev_device_get_parent_with_subsystem_devtype(dev, subsystem, 0);
+        if (!parent_dev)
             goto cleanup;
 
-        if (!checkDeviceType(dev))
+        if (!checkDeviceType(parent_dev))
             goto cleanup;
     }
 


### PR DESCRIPTION
Overwriting the original device pointer would unref an incorrect
instance during cleanup, resulting to a memory leak.

Change-Id: Ieac4a2de98eec329aa42dedce9601c44348ba4d9
