### PR TITLE
[rcc] Use stable ordering of files to get reproducible builds

### DIFF
--- a/src/tools/rcc/main.cpp
+++ b/src/tools/rcc/main.cpp
@@ -254,10 +254,5 @@ QT_END_NAMESPACE
 
 int main(int argc, char *argv[])
 {
-    // rcc uses a QHash to store files in the resource system.
-    // we must force a certain hash order when testing or tst_rcc will fail, see QTBUG-25078
-    if (!qEnvironmentVariableIsEmpty("QT_RCC_TEST") && !qt_qhash_seed.testAndSetRelaxed(-1, 0))
-        qFatal("Cannot force QHash seed for testing as requested");
-
     return QT_PREPEND_NAMESPACE(runRcc)(argc, argv);
 }

--- a/src/tools/rcc/rcc.cpp
+++ b/src/tools/rcc/rcc.cpp
@@ -123,7 +123,9 @@ public:
     QLocale::Country m_country;
     QFileInfo m_fileInfo;
     RCCFileInfo *m_parent;
-    QHash<QString, RCCFileInfo*> m_children;
+    // use a QMap to get a stable ordering of children
+    // so that the generated files don't change every build
+    QMap<QString, RCCFileInfo*> m_children;
     int m_compressLevel;
     int m_compressThreshold;
 
@@ -679,7 +681,7 @@ QStringList RCCResourceLibrary::dataFiles() const
     pending.push(m_root);
     while (!pending.isEmpty()) {
         RCCFileInfo *file = pending.pop();
-        for (QHash<QString, RCCFileInfo*>::iterator it = file->m_children.begin();
+        for (QMap<QString, RCCFileInfo*>::iterator it = file->m_children.begin();
             it != file->m_children.end(); ++it) {
             RCCFileInfo *child = it.value();
             if (child->m_flags & RCCFileInfo::Directory)
@@ -693,7 +695,7 @@ QStringList RCCResourceLibrary::dataFiles() const
 // Determine map of resource identifier (':/newPrefix/images/p1.png') to file via recursion
 static void resourceDataFileMapRecursion(const RCCFileInfo *m_root, const QString &path, RCCResourceLibrary::ResourceDataFileMap &m)
 {
-    typedef QHash<QString, RCCFileInfo*>::const_iterator ChildConstIterator;
+    typedef QMap<QString, RCCFileInfo*>::const_iterator ChildConstIterator;
     const QChar slash = QLatin1Char('/');
     const ChildConstIterator cend = m_root->m_children.constEnd();
     for (ChildConstIterator it = m_root->m_children.constBegin(); it != cend; ++it) {
@@ -828,7 +830,7 @@ bool RCCResourceLibrary::writeDataBlobs()
     QString errorMessage;
     while (!pending.isEmpty()) {
         RCCFileInfo *file = pending.pop();
-        for (QHash<QString, RCCFileInfo*>::iterator it = file->m_children.begin();
+        for (QMap<QString, RCCFileInfo*>::iterator it = file->m_children.begin();
             it != file->m_children.end(); ++it) {
             RCCFileInfo *child = it.value();
             if (child->m_flags & RCCFileInfo::Directory)
@@ -864,7 +866,7 @@ bool RCCResourceLibrary::writeDataNames()
     qint64 offset = 0;
     while (!pending.isEmpty()) {
         RCCFileInfo *file = pending.pop();
-        for (QHash<QString, RCCFileInfo*>::iterator it = file->m_children.begin();
+        for (QMap<QString, RCCFileInfo*>::iterator it = file->m_children.begin();
             it != file->m_children.end(); ++it) {
             RCCFileInfo *child = it.value();
             if (child->m_flags & RCCFileInfo::Directory)

--- a/tests/auto/tools/rcc/tst_rcc.cpp
+++ b/tests/auto/tools/rcc/tst_rcc.cpp
@@ -77,9 +77,6 @@ private:
 
 void tst_rcc::initTestCase()
 {
-    // rcc uses a QHash to store files in the resource system.
-    // we must force a certain hash order when testing or tst_rcc will fail, see QTBUG-25078
-    QVERIFY(qputenv("QT_RCC_TEST", "1"));
     m_rcc = QLibraryInfo::location(QLibraryInfo::BinariesPath) + QLatin1String("/rcc");
 }
 


### PR DESCRIPTION
Using a QMap instead of a QHash makes the output reproducible.

After this change the QT_RCC_TEST workaround in the autotests was no longer needed so I removed it for clarity.
